### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 pytesseract = "*"
 opencv-python = "*"
-fuzzywuzzy = {extras = ["speedup"],version = "*"}
+fuzzywuzzy = "*"
 
 [requires]
 python_version = "3.7"

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setup(
     url='https://github.com/apm1467/videocr',
     download_url='https://github.com/apm1467/videocr/archive/v0.1.6.tar.gz',
     install_requires=[
-        'fuzzywuzzy>=0.17',
-        'python-Levenshtein>=0.12',
+        'rapidfuzz>=0.2.1',
         'opencv-python>=4.1,<5.0',
         'pytesseract>=0.2.6'
     ],

--- a/videocr/models.py
+++ b/videocr/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import List
 from dataclasses import dataclass
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 @dataclass


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.

This does not update the Pipfile.lock