### PR TITLE
speed increase by (optionally) skipping (most) frames

### DIFF
--- a/videocr/api.py
+++ b/videocr/api.py
@@ -4,7 +4,7 @@ from .video import Video
 
 def get_subtitles(
         video_path: str, lang='eng', time_start='0:00', time_end='',
-        conf_threshold=65, sim_threshold=90, use_fullframe=False) -> str:
+        conf_threshold=65, sim_threshold=90, use_fullframe=False, skip_frames=0) -> str:
     utils.download_lang_data(lang)
 
     v = Video(video_path)


### PR DESCRIPTION
Text is generally aimed at human reading thus usually lasting ~ 1 second or so (rarely less than 500ms)

We can increase speed by 10 or 15 by skipping frames. Said otherwise only OCR'ing one frame every (fps/2)