### PR TITLE
Uplate Levenshtein import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     download_url='https://github.com/apm1467/videocr/archive/v0.1.6.tar.gz',
     install_requires=[
         'fuzzywuzzy>=0.17',
-        'python-Levenshtein>=0.12',
+        'Levenshtein>=0.12',
         'opencv-python>=4.1,<5.0',
         'pytesseract>=0.2.6'
     ],


### PR DESCRIPTION
The python-Levenshtein package was renamed to Levenshtein a few years ago.
As of now, python-Levenshtein only exists in pypi as a stub for installing Levenshtein.


So, we can directly depend on Levenshtein.